### PR TITLE
specify spring boot main class

### DIFF
--- a/samples/core/pom.xml
+++ b/samples/core/pom.xml
@@ -243,6 +243,17 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+	<configuration>
+        <mainClass>io.oasp.gastronomy.restaurant.SpringBootApp</mainClass>
+        <layout>ZIP</layout>
+	    </configuration>
+	    <executions>
+		<execution>
+		    <goals>
+			<goal>repackage</goal>
+		    </goals>
+		</execution>
+	    </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I had to make this change to run the packaged Spring Boot application with:

java -jar samples/core/target/oasp4j-sample-core-dev-SNAPSHOT.jar

Now the file is 52Mb of size and has all the jar dependencies embedded
