### PR TITLE
Force locale to en_EN in order to make the tests pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
           <configuration>
+            <!-- force locale to en_EN or tests will fail in other locales -->
+            <argLine>-Duser.language=en -Duser.region=EN</argLine>
             <!-- Surefire changed the default to the project.build.directory causing trouble with file paths to test resources -->
             <workingDirectory>${basedir}</workingDirectory>
           </configuration>


### PR DESCRIPTION
If language and region are not set in command line then the tests fail when only performing `mvn package` to generate project (in an es_ES environment)

Maybe this works when working with OASP IDE setup but I'm currently building everything "on the cloud" and don't have this type of help.
